### PR TITLE
add externalKey entry in encryptionProcedure

### DIFF
--- a/src/cascade.js
+++ b/src/cascade.js
@@ -72,6 +72,9 @@ class Cascade extends Array {
 
     const precedence = this.slice(0, this.length -1);
     await Promise.all(precedence.map( async (proc, idx) => {
+      if (typeof proc.config.encrypt.externalKey === 'undefined' || proc.config.encrypt.externalKey) {
+        throw new Error('PrecedenceMustBeExternalKey');
+      }
       if (typeof proc.config.encrypt.onetimeKey === 'undefined') throw new Error('NoKeyParamsGiven');
 
       const suiteObject = {encrypt_decrypt: proc.config.encrypt.suite};
@@ -105,6 +108,9 @@ class Cascade extends Array {
       }
 
       this[idx].keys = await importKeys('object', {keys:onetimeKeyObject, suite: suiteObject, mode: modeArray});
+      if (typeof this[this.length-1].config.encrypt.externalKey === 'undefined' || !this[this.length-1].config.encrypt.externalKey) {
+        throw new Error('FinalStepMustBeExternalKey');
+      }
     }));
   }
 

--- a/test/params-basic.js
+++ b/test/params-basic.js
@@ -11,30 +11,40 @@ const modulusLength = [ 2048, 2048 ];
 const userIds = [ 'test@example.com' ];
 const paramArray = [{name: 'ec', param: curves}, {name: 'rsa', param: modulusLength}];
 
-const openpgpEncryptConf = { suite: 'openpgp', options: { detached: true, compression: 'zlib' }};
+const openpgpEncryptConf = { externalKey: true, suite: 'openpgp', options: { detached: true, compression: 'zlib' }};
 const openpgpSignConf = {required: true, suite: 'openpgp', options: {}};
 
-const jscuSessionEncryptConf = {suite: 'jscu', options: {name: 'AES-GCM'}};
+const jscuSessionEncryptConf = {externalKey: true, suite: 'jscu', options: {name: 'AES-GCM'}};
 const openpgpgSessionEncryptConf = {suite: 'openpgp', options: {algorithm: 'aes256', aead: true, aead_mode: 'eax' }};
 
 const jscuOnetimeSessionEncryptConf = {
-  onetimeKey: {keyParams: {type: 'session', length: 32}},
+  externalKey: false,
   suite: 'jscu',
+  onetimeKey: {keyParams: {type: 'session', length: 32}},
+  options: {name: 'AES-GCM'}
+};
+const jscuOnetimeSessionEncryptConfWithoutExternalKey = {
+  externalKey: true,
+  suite: 'jscu',
+  onetimeKey: {keyParams: {type: 'session', length: 32}},
   options: {name: 'AES-GCM'}
 };
 const openpgpOnetimeSessionEncryptConf = {
-  onetimeKey: {keyParams: {type: 'session', length: 32}},
+  externalKey: false,
   suite: 'openpgp',
+  onetimeKey: {keyParams: {type: 'session', length: 32}},
   options: {algorithm: 'aes256', aead: true, aead_mode: 'eax' }
 };
 
 const jscuOnetimePublicEncryptConf = {
+  externalKey: false,
   suite: 'jscu',
   onetimeKey: {keyParams: {type: 'ec', curve: 'P-256'} },
   options: { hash: 'SHA-256', encrypt: 'AES-GCM', keyLength: 32, info: '' }
 };
 
 const openpgpOnetimePublicEncryptConf = {
+  externalKey: false,
   suite: 'openpgp',
   onetimeKey: {userIds: ['user@example.com'], keyParams: {type: 'ec', keyExpirationTime: 0, curve: 'P-256'}},
   options: { detached: true, compression: 'zlib' }
@@ -81,6 +91,7 @@ class ParamsBasic{
 
   jscuEncryptConf (paramObject, idx) {
     return {
+      externalKey: true,
       suite: 'jscu',
       options: (paramObject.name === 'ec')
         ? {
@@ -92,6 +103,14 @@ class ParamsBasic{
   }
 
   jscuEncryptConfEphemeral (paramObject) {
+    return {
+      externalKey: true,
+      suite: 'jscu',
+      options: (paramObject.name === 'ec') ? { hash: 'SHA-256', encrypt: 'AES-GCM', keyLength: 32, info: '' } : {hash: 'SHA-256'},
+    };
+  }
+
+  jscuEncryptConfEphemeralNoExternalKey (paramObject) {
     return {
       suite: 'jscu',
       options: (paramObject.name === 'ec') ? { hash: 'SHA-256', encrypt: 'AES-GCM', keyLength: 32, info: '' } : {hash: 'SHA-256'},
@@ -112,6 +131,7 @@ class ParamsBasic{
   get jscuSessionEncryptConf () { return jscuSessionEncryptConf; }
   get openpgpgSessionEncryptConf () { return openpgpgSessionEncryptConf; }
   get jscuOnetimeSessionEncryptConf () { return jscuOnetimeSessionEncryptConf; }
+  get jscuOnetimeSessionEncryptConfWithoutExternalKey () { return jscuOnetimeSessionEncryptConfWithoutExternalKey; }
   get openpgpOnetimeSessionEncryptConf () { return openpgpOnetimeSessionEncryptConf; }
   get jscuOnetimePublicEncryptConf () { return jscuOnetimePublicEncryptConf; }
   get openpgpOnetimePublicEncryptConf () { return openpgpOnetimePublicEncryptConf; }


### PR DESCRIPTION
An encryptionProcedure for x-brid encryption is confusing because what key is used in each step. Although the existence of "encrypt.onetimeKey" indicate it, it would be a good idea to specify the origin of key in each step explicitly.

This PR adds encrypt.externalKey in the encryptionProcedure, which is a boolean, and check the value in _initEncryptionProcedure().